### PR TITLE
Fix #1: Add 'private' boolean flag to github_init_pkg_repo

### DIFF
--- a/pywharf_backends/github/impl.py
+++ b/pywharf_backends/github/impl.py
@@ -49,6 +49,7 @@ class GitHubConfig(PkgRepoConfig):
     repo: str
     branch: str = 'master'
     index_filename: str = 'index.toml'
+    private: bool = True
 
     def __init__(self, **data):
         super().__init__(**data)
@@ -401,6 +402,7 @@ def github_init_pkg_repo(
         pywharf_version: str = '0.2.0',
         enable_gh_pages: bool = False,
         dry_run: bool = False,
+        private: bool = basic_model_get_default(GitHubConfig, 'private')
 ):
     docker_image = f'docker://pywharf/pywharf:{pywharf_version}'
 
@@ -484,6 +486,7 @@ jobs:
             has_downloads=False,
             has_projects=False,
             auto_init=True,
+            private=private
     )
     # GitHub might take some time to create the READMD.md.
     time.sleep(3.0)


### PR DESCRIPTION
This PR adds a private flag to the backend configuration. The flag is on by default. Fixes the issue #1 by @huntzhan.

Gotchas:
- Boolean flags are somewhat quirky on the `fire` side. Check out [this part of its guide](https://github.com/google/python-fire/blob/fac1ea00430757fd3aa3d8e2b5f8226d25afe9b0/docs/guide.md#boolean-arguments).
- I'm not sure how well this feature would play with the Github pages feature. Any suggestions?
- I'm not sure whether the arguments will be passed on from the docker image.


